### PR TITLE
TestContainers compatibility

### DIFF
--- a/soldevelo/jmx-exporter/1/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/soldevelo/jmx-exporter/1/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -42,10 +42,10 @@ print_welcome_page() {
 #   None
 #########################
 print_image_welcome_page() {
-    local github_url="https://github.com/bitnami/containers"
+    local github_url="https://github.com/soldevelo/containers"
 
     info ""
-    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info "${BOLD}Welcome to the SolDevelo ${BITNAMI_APP_NAME} container${RESET}"
     info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
     info "${YELLOW}NOTICE: Starting August 28th, 2025, only a limited subset of images/charts will remain available for free. Backup will be available for some time at the 'Bitnami Legacy' repository. More info at https://github.com/bitnami/containers/issues/83267${RESET}"
     info ""

--- a/soldevelo/kafka/3.7/debian-12/Dockerfile
+++ b/soldevelo/kafka/3.7/debian-12/Dockerfile
@@ -53,6 +53,7 @@ RUN ln -s /opt/bitnami/scripts/kafka/entrypoint.sh /entrypoint.sh
 RUN ln -s /opt/bitnami/scripts/kafka/run.sh /run.sh
 
 COPY rootfs /
+RUN chmod +x /etc/kafka/docker/run
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/kafka/postunpack.sh
 ENV APP_VERSION="3.7.1" \

--- a/soldevelo/kafka/3.7/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/soldevelo/kafka/3.7/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -42,10 +42,10 @@ print_welcome_page() {
 #   None
 #########################
 print_image_welcome_page() {
-    local github_url="https://github.com/bitnami/containers"
+    local github_url="https://github.com/soldevelo/containers"
 
     info ""
-    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info "${BOLD}Welcome to the SolDevelo ${BITNAMI_APP_NAME} container${RESET}"
     info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
     info "Submit issues and feature requests at ${BOLD}${github_url}/issues${RESET}"
     info "Upgrade to Tanzu Application Catalog for production environments to access custom-configured and pre-packaged software components. Gain enhanced features, including Software Bill of Materials (SBOM), CVE scan result reports, and VEX documents. To learn more, visit ${BOLD}https://bitnami.com/enterprise${RESET}"

--- a/soldevelo/kafka/3.7/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/3.7/debian-12/rootfs/etc/kafka/docker/run
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2025 SolDevelo
+# SPDX-License-Identifier: Apache-2.0
+#
+# Testcontainers-compatible entrypoint wrapper
+# This script provides compatibility with the apache/kafka Docker image contract
+
+set -e
+
+echo "/etc/kafka/docker/run invoked"
+
+# Set default environment variables for Testcontainers compatibility
+# These can be overridden by passing environment variables to the container
+export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
+export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
+export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"
+export KAFKA_CFG_LISTENERS="${KAFKA_CFG_LISTENERS:-PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093}"
+export KAFKA_CFG_ADVERTISED_LISTENERS="${KAFKA_CFG_ADVERTISED_LISTENERS:-PLAINTEXT://localhost:9092}"
+export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP="${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT}"
+export KAFKA_CFG_CONTROLLER_LISTENER_NAMES="${KAFKA_CFG_CONTROLLER_LISTENER_NAMES:-CONTROLLER}"
+export KAFKA_CFG_INTER_BROKER_LISTENER_NAME="${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-PLAINTEXT}"
+
+# Delegate to the actual Kafka entrypoint
+exec /opt/bitnami/scripts/kafka/entrypoint.sh /opt/bitnami/scripts/kafka/run.sh "$@"
+

--- a/soldevelo/kafka/3.7/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/3.7/debian-12/rootfs/etc/kafka/docker/run
@@ -11,6 +11,7 @@ echo "/etc/kafka/docker/run invoked"
 
 # Set default environment variables for Testcontainers compatibility
 # These can be overridden by passing environment variables to the container
+export TESTCONTAINERS_KAFKA=true
 export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
 export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
 export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"

--- a/soldevelo/kafka/3.7/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
+++ b/soldevelo/kafka/3.7/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
@@ -20,13 +20,41 @@ if [[ -f "${KAFKA_CONF_DIR}/kafka_jaas.conf" ]]; then
     export KAFKA_OPTS="${KAFKA_OPTS:-} -Djava.security.auth.login.config=${KAFKA_CONF_DIR}/kafka_jaas.conf"
 fi
 
+# Extract broker/node ID for ready logging
+KAFKA_ID=""
+if [[ -n "${KAFKA_CFG_NODE_ID:-}" ]]; then
+    # KRaft mode uses node.id
+    KAFKA_ID="${KAFKA_CFG_NODE_ID}"
+elif [[ -n "${KAFKA_CFG_BROKER_ID:-}" ]]; then
+    # Zookeeper mode uses broker.id
+    KAFKA_ID="${KAFKA_CFG_BROKER_ID}"
+fi
+
 cmd="$KAFKA_HOME/bin/kafka-server-start.sh"
 args=("$KAFKA_CONF_FILE")
 ! is_empty_value "${KAFKA_EXTRA_FLAGS:-}" && args=("${args[@]}" "${KAFKA_EXTRA_FLAGS[@]}")
 
 info "** Starting Kafka **"
+
+# Monitor function to detect Kafka ready state
+monitor_kafka_output() {
+    local kafka_id="$1"
+    local logged_ready=false
+    
+    while IFS= read -r line; do
+        echo "$line"
+        if [[ "$logged_ready" == false ]] && echo "$line" | grep -q "Kafka Server started"; then
+            if [[ -n "$kafka_id" ]]; then
+                info "KafkaServer id=${kafka_id} started."
+            fi
+            logged_ready=true
+        fi
+    done
+}
+
+# Start Kafka with output monitoring
 if am_i_root; then
-    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@"
+    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 else
-    exec "$cmd" "${args[@]}" "$@"
+    exec "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 fi

--- a/soldevelo/kafka/3.7/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
+++ b/soldevelo/kafka/3.7/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
@@ -52,9 +52,18 @@ monitor_kafka_output() {
     done
 }
 
-# Start Kafka with output monitoring
-if am_i_root; then
-    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
+if [[ "${TESTCONTAINERS_KAFKA:-false}" == "true" ]]; then
+    # Start Kafka with output monitoring (only for Testcontainers)
+    if am_i_root; then
+        exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
+    else
+        exec "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
+    fi
 else
-    exec "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
+    # Standard Bitnami behavior - preserve signal handling
+    if am_i_root; then
+        exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@"
+    else
+        exec "$cmd" "${args[@]}" "$@"
+    fi
 fi

--- a/soldevelo/kafka/3.9/debian-12/Dockerfile
+++ b/soldevelo/kafka/3.9/debian-12/Dockerfile
@@ -51,6 +51,7 @@ RUN ln -s /opt/bitnami/scripts/kafka/entrypoint.sh /entrypoint.sh
 RUN ln -s /opt/bitnami/scripts/kafka/run.sh /run.sh
 
 COPY rootfs /
+RUN chmod +x /etc/kafka/docker/run
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/kafka/postunpack.sh
 ENV APP_VERSION="3.9.0" \

--- a/soldevelo/kafka/3.9/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/soldevelo/kafka/3.9/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -42,10 +42,10 @@ print_welcome_page() {
 #   None
 #########################
 print_image_welcome_page() {
-    local github_url="https://github.com/bitnami/containers"
+    local github_url="https://github.com/soldevelo/containers"
 
     info ""
-    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info "${BOLD}Welcome to the SolDevelo ${BITNAMI_APP_NAME} container${RESET}"
     info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
     info "Did you know there are enterprise versions of the Bitnami catalog? For enhanced secure software supply chain features, unlimited pulls from Docker, LTS support, or application customization, see Bitnami Premium or Tanzu Application Catalog. See https://www.arrow.com/globalecs/na/vendors/bitnami/ for more information."
     info ""

--- a/soldevelo/kafka/3.9/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/3.9/debian-12/rootfs/etc/kafka/docker/run
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2025 SolDevelo
+# SPDX-License-Identifier: Apache-2.0
+#
+# Testcontainers-compatible entrypoint wrapper
+# This script provides compatibility with the apache/kafka Docker image contract
+
+set -e
+
+echo "/etc/kafka/docker/run invoked"
+
+# Set default environment variables for Testcontainers compatibility
+# These can be overridden by passing environment variables to the container
+export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
+export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
+export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"
+export KAFKA_CFG_LISTENERS="${KAFKA_CFG_LISTENERS:-PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093}"
+export KAFKA_CFG_ADVERTISED_LISTENERS="${KAFKA_CFG_ADVERTISED_LISTENERS:-PLAINTEXT://localhost:9092}"
+export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP="${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT}"
+export KAFKA_CFG_CONTROLLER_LISTENER_NAMES="${KAFKA_CFG_CONTROLLER_LISTENER_NAMES:-CONTROLLER}"
+export KAFKA_CFG_INTER_BROKER_LISTENER_NAME="${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-PLAINTEXT}"
+
+# Delegate to the actual Kafka entrypoint
+exec /opt/bitnami/scripts/kafka/entrypoint.sh /opt/bitnami/scripts/kafka/run.sh "$@"

--- a/soldevelo/kafka/3.9/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/3.9/debian-12/rootfs/etc/kafka/docker/run
@@ -11,6 +11,7 @@ echo "/etc/kafka/docker/run invoked"
 
 # Set default environment variables for Testcontainers compatibility
 # These can be overridden by passing environment variables to the container
+export TESTCONTAINERS_KAFKA=true
 export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
 export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
 export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"

--- a/soldevelo/kafka/3.9/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
+++ b/soldevelo/kafka/3.9/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
@@ -20,13 +20,42 @@ if [[ -f "${KAFKA_CONF_DIR}/kafka_jaas.conf" ]]; then
     export KAFKA_OPTS="${KAFKA_OPTS:-} -Djava.security.auth.login.config=${KAFKA_CONF_DIR}/kafka_jaas.conf"
 fi
 
+# Extract broker/node ID for ready logging
+KAFKA_ID=""
+if [[ -n "${KAFKA_CFG_NODE_ID:-}" ]]; then
+    # KRaft mode uses node.id
+    KAFKA_ID="${KAFKA_CFG_NODE_ID}"
+elif [[ -n "${KAFKA_CFG_BROKER_ID:-}" ]]; then
+    # Zookeeper mode uses broker.id
+    KAFKA_ID="${KAFKA_CFG_BROKER_ID}"
+fi
+
 cmd="$KAFKA_HOME/bin/kafka-server-start.sh"
 args=("$KAFKA_CONF_FILE")
 ! is_empty_value "${KAFKA_EXTRA_FLAGS:-}" && args=("${args[@]}" "${KAFKA_EXTRA_FLAGS[@]}")
 
 info "** Starting Kafka **"
+
+# Monitor function to detect Kafka ready state
+monitor_kafka_output() {
+    local kafka_id="$1"
+    local logged_ready=false
+    
+    while IFS= read -r line; do
+        echo "$line"
+        if [[ "$logged_ready" == false ]] && echo "$line" | grep -q "started (kafka.server.KafkaServer)"; then
+            if [[ -n "$kafka_id" ]]; then
+                info "KafkaServer id=${kafka_id} started."
+            fi
+            logged_ready=true
+        fi
+    done
+}
+
+# Start Kafka with output monitoring
 if am_i_root; then
-    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@"
+    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 else
-    exec "$cmd" "${args[@]}" "$@"
+    exec "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 fi
+

--- a/soldevelo/kafka/4.0/debian-12/Dockerfile
+++ b/soldevelo/kafka/4.0/debian-12/Dockerfile
@@ -51,6 +51,7 @@ RUN ln -s /opt/bitnami/scripts/kafka/entrypoint.sh /entrypoint.sh
 RUN ln -s /opt/bitnami/scripts/kafka/run.sh /run.sh
 
 COPY rootfs /
+RUN chmod +x /etc/kafka/docker/run
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/kafka/postunpack.sh
 ENV APP_VERSION="4.0.0" \

--- a/soldevelo/kafka/4.0/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/soldevelo/kafka/4.0/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -42,10 +42,10 @@ print_welcome_page() {
 #   None
 #########################
 print_image_welcome_page() {
-    local github_url="https://github.com/bitnami/containers"
+    local github_url="https://github.com/soldevelo/containers"
 
     info ""
-    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info "${BOLD}Welcome to the SolDevelo ${BITNAMI_APP_NAME} container${RESET}"
     info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
     info "${YELLOW}NOTICE: Starting August 28th, 2025, only a limited subset of images/charts will remain available for free. Backup will be available for some time at the 'Bitnami Legacy' repository. More info at https://github.com/bitnami/containers/issues/83267${RESET}"
     info ""

--- a/soldevelo/kafka/4.0/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/4.0/debian-12/rootfs/etc/kafka/docker/run
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2025 SolDevelo
+# SPDX-License-Identifier: Apache-2.0
+#
+# Testcontainers-compatible entrypoint wrapper
+# This script provides compatibility with the apache/kafka Docker image contract
+
+set -e
+
+echo "/etc/kafka/docker/run invoked"
+
+# Set default environment variables for Testcontainers compatibility
+# These can be overridden by passing environment variables to the container
+export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
+export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
+export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"
+export KAFKA_CFG_LISTENERS="${KAFKA_CFG_LISTENERS:-PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093}"
+export KAFKA_CFG_ADVERTISED_LISTENERS="${KAFKA_CFG_ADVERTISED_LISTENERS:-PLAINTEXT://localhost:9092}"
+export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP="${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT}"
+export KAFKA_CFG_CONTROLLER_LISTENER_NAMES="${KAFKA_CFG_CONTROLLER_LISTENER_NAMES:-CONTROLLER}"
+export KAFKA_CFG_INTER_BROKER_LISTENER_NAME="${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-PLAINTEXT}"
+
+# Delegate to the actual Kafka entrypoint
+exec /opt/bitnami/scripts/kafka/entrypoint.sh /opt/bitnami/scripts/kafka/run.sh "$@"

--- a/soldevelo/kafka/4.0/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/4.0/debian-12/rootfs/etc/kafka/docker/run
@@ -11,6 +11,7 @@ echo "/etc/kafka/docker/run invoked"
 
 # Set default environment variables for Testcontainers compatibility
 # These can be overridden by passing environment variables to the container
+export TESTCONTAINERS_KAFKA=true
 export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
 export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
 export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"

--- a/soldevelo/kafka/4.0/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
+++ b/soldevelo/kafka/4.0/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
@@ -20,13 +20,42 @@ if [[ -f "${KAFKA_CONF_DIR}/kafka_jaas.conf" ]]; then
     export KAFKA_OPTS="${KAFKA_OPTS:-} -Djava.security.auth.login.config=${KAFKA_CONF_DIR}/kafka_jaas.conf"
 fi
 
+# Extract broker/node ID for ready logging
+KAFKA_ID=""
+if [[ -n "${KAFKA_CFG_NODE_ID:-}" ]]; then
+    # KRaft mode uses node.id
+    KAFKA_ID="${KAFKA_CFG_NODE_ID}"
+elif [[ -n "${KAFKA_CFG_BROKER_ID:-}" ]]; then
+    # Zookeeper mode uses broker.id
+    KAFKA_ID="${KAFKA_CFG_BROKER_ID}"
+fi
+
 cmd="$KAFKA_HOME/bin/kafka-server-start.sh"
 args=("$KAFKA_CONF_FILE")
 ! is_empty_value "${KAFKA_EXTRA_FLAGS:-}" && args=("${args[@]}" "${KAFKA_EXTRA_FLAGS[@]}")
 
 info "** Starting Kafka **"
+
+# Monitor function to detect Kafka ready state
+monitor_kafka_output() {
+    local kafka_id="$1"
+    local logged_ready=false
+    
+    while IFS= read -r line; do
+        echo "$line"
+        if [[ "$logged_ready" == false ]] && echo "$line" | grep -q "started (kafka.server.KafkaServer)"; then
+            if [[ -n "$kafka_id" ]]; then
+                info "KafkaServer id=${kafka_id} started."
+            fi
+            logged_ready=true
+        fi
+    done
+}
+
+# Start Kafka with output monitoring
 if am_i_root; then
-    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@"
+    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 else
-    exec "$cmd" "${args[@]}" "$@"
+    exec "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 fi
+

--- a/soldevelo/kafka/4.1/debian-12/Dockerfile
+++ b/soldevelo/kafka/4.1/debian-12/Dockerfile
@@ -50,6 +50,7 @@ RUN ln -s /opt/bitnami/scripts/kafka/entrypoint.sh /entrypoint.sh
 RUN ln -s /opt/bitnami/scripts/kafka/run.sh /run.sh
 
 COPY rootfs /
+RUN chmod +x /etc/kafka/docker/run
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/kafka/postunpack.sh
 ENV APP_VERSION="4.1.1" \

--- a/soldevelo/kafka/4.1/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/soldevelo/kafka/4.1/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -42,10 +42,10 @@ print_welcome_page() {
 #   None
 #########################
 print_image_welcome_page() {
-    local github_url="https://github.com/bitnami/containers"
+    local github_url="https://github.com/soldevelo/containers"
 
     info ""
-    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info "${BOLD}Welcome to the SolDevelo ${BITNAMI_APP_NAME} container${RESET}"
     info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
     info "${YELLOW}NOTICE: Starting August 28th, 2025, only a limited subset of images/charts will remain available for free. Backup will be available for some time at the 'Bitnami Legacy' repository. More info at https://github.com/bitnami/containers/issues/83267${RESET}"
     info ""

--- a/soldevelo/kafka/4.1/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/4.1/debian-12/rootfs/etc/kafka/docker/run
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2025 SolDevelo
+# SPDX-License-Identifier: Apache-2.0
+#
+# Testcontainers-compatible entrypoint wrapper
+# This script provides compatibility with the apache/kafka Docker image contract
+
+set -e
+
+echo "/etc/kafka/docker/run invoked"
+
+# Set default environment variables for Testcontainers compatibility
+# These can be overridden by passing environment variables to the container
+export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
+export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
+export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"
+export KAFKA_CFG_LISTENERS="${KAFKA_CFG_LISTENERS:-PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093}"
+export KAFKA_CFG_ADVERTISED_LISTENERS="${KAFKA_CFG_ADVERTISED_LISTENERS:-PLAINTEXT://localhost:9092}"
+export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP="${KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP:-CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT}"
+export KAFKA_CFG_CONTROLLER_LISTENER_NAMES="${KAFKA_CFG_CONTROLLER_LISTENER_NAMES:-CONTROLLER}"
+export KAFKA_CFG_INTER_BROKER_LISTENER_NAME="${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-PLAINTEXT}"
+
+# Delegate to the actual Kafka entrypoint
+exec /opt/bitnami/scripts/kafka/entrypoint.sh /opt/bitnami/scripts/kafka/run.sh "$@"

--- a/soldevelo/kafka/4.1/debian-12/rootfs/etc/kafka/docker/run
+++ b/soldevelo/kafka/4.1/debian-12/rootfs/etc/kafka/docker/run
@@ -11,6 +11,7 @@ echo "/etc/kafka/docker/run invoked"
 
 # Set default environment variables for Testcontainers compatibility
 # These can be overridden by passing environment variables to the container
+export TESTCONTAINERS_KAFKA=true
 export KAFKA_CFG_NODE_ID="${KAFKA_CFG_NODE_ID:-1}"
 export KAFKA_CFG_PROCESS_ROLES="${KAFKA_CFG_PROCESS_ROLES:-broker,controller}"
 export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS="${KAFKA_CFG_CONTROLLER_QUORUM_VOTERS:-1@localhost:9093}"

--- a/soldevelo/kafka/4.1/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
+++ b/soldevelo/kafka/4.1/debian-12/rootfs/opt/bitnami/scripts/kafka/run.sh
@@ -20,13 +20,42 @@ if [[ -f "${KAFKA_CONF_DIR}/kafka_jaas.conf" ]]; then
     export KAFKA_OPTS="${KAFKA_OPTS:-} -Djava.security.auth.login.config=${KAFKA_CONF_DIR}/kafka_jaas.conf"
 fi
 
+# Extract broker/node ID for ready logging
+KAFKA_ID=""
+if [[ -n "${KAFKA_CFG_NODE_ID:-}" ]]; then
+    # KRaft mode uses node.id
+    KAFKA_ID="${KAFKA_CFG_NODE_ID}"
+elif [[ -n "${KAFKA_CFG_BROKER_ID:-}" ]]; then
+    # Zookeeper mode uses broker.id
+    KAFKA_ID="${KAFKA_CFG_BROKER_ID}"
+fi
+
 cmd="$KAFKA_HOME/bin/kafka-server-start.sh"
 args=("$KAFKA_CONF_FILE")
 ! is_empty_value "${KAFKA_EXTRA_FLAGS:-}" && args=("${args[@]}" "${KAFKA_EXTRA_FLAGS[@]}")
 
 info "** Starting Kafka **"
+
+# Monitor function to detect Kafka ready state
+monitor_kafka_output() {
+    local kafka_id="$1"
+    local logged_ready=false
+    
+    while IFS= read -r line; do
+        echo "$line"
+        if [[ "$logged_ready" == false ]] && echo "$line" | grep -q "started (kafka.server.KafkaServer)"; then
+            if [[ -n "$kafka_id" ]]; then
+                info "KafkaServer id=${kafka_id} started."
+            fi
+            logged_ready=true
+        fi
+    done
+}
+
+# Start Kafka with output monitoring
 if am_i_root; then
-    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@"
+    exec_as_user "$KAFKA_DAEMON_USER" "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 else
-    exec "$cmd" "${args[@]}" "$@"
+    exec "$cmd" "${args[@]}" "$@" 2>&1 | monitor_kafka_output "$KAFKA_ID"
 fi
+


### PR DESCRIPTION
We can now run our image in  the TestContainers framework as a substitute for apache/kafka.

* Added /etc/kafka/docker/run script which is executed by TestContainers
* Changed logs about Bitnami to SolDevelo